### PR TITLE
Ensure Float64Array is supported

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4,7 +4,7 @@
 (function(undefined) {
     "use strict";
     
-    if (typeof Float32Array === "undefined") {
+    if (typeof Float32Array === "undefined" || typeof Float64Array === "undefined") {
         /*jshint latedef:true */
         setupTypedArray();
         /*jshint latedef:false */


### PR DESCRIPTION
I encountered an issue while using this (awesome) library where `Float32Array` was supported while `Float64Array` was not. Specifically, in my headless Phantom.js integration tests. [See this issue](https://code.google.com/p/phantomjs/issues/detail?id=607&can=1&q=Float64Array)

I'm unsure how to run the tests for this library so apologies for not being able to check that, but this simple fix appears to be working just fine :guitar: :saxophone:
