### PR TITLE
export timbre in commonJS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ T("sin", {freq:880, mul:0.5}).play();
 MIT
 
 ## ChangeLog ##
+**14.05.29** (355.96KB)
+* Fixed: Export for CommonJS env [#19](https://github.com/mohayonao/timbre.js/issues/19)
+
 **14.05.28** (355.91KB)
 * Fixed: [#19](https://github.com/mohayonao/timbre.js/issues/19)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timbre",
-  "version": "14.05.15",
+  "version": "14.05.29",
   "description": "JavaScript library for objective sound programming",
   "author": "nao yonamine <mohayonao@gmail.com>",
   "repository": {

--- a/src/core.js
+++ b/src/core.js
@@ -2434,7 +2434,7 @@
 
     var exports = timbre;
 
-    if (_envtype === "node") {
+    if (_envtype === "node" || typeof module !== "undefined" && module.exports) {
         module.exports = global.timbre = exports;
     } else if (_envtype === "browser") {
         exports.noConflict = (function() {

--- a/timbre.dev.js
+++ b/timbre.dev.js
@@ -18,7 +18,7 @@
     var ACCEPT_SAMPLERATES = [8000,11025,12000,16000,22050,24000,32000,44100,48000];
     var ACCEPT_CELLSIZES = [32,64,128,256];
 
-    var _ver = "14.05.28";
+    var _ver = "14.05.29";
     var _sys = null;
     var _constructors = {};
     var _factories    = {};
@@ -2434,7 +2434,7 @@
 
     var exports = timbre;
 
-    if (_envtype === "node") {
+    if (_envtype === "node" || typeof module !== "undefined" && module.exports) {
         module.exports = global.timbre = exports;
     } else if (_envtype === "browser") {
         exports.noConflict = (function() {


### PR DESCRIPTION
Thanks for a7e9dab6db35710d0d83244127e32fba70336911 . It definitely fixed the timbre env variable issue, but still need the timbre object exported in the commonJS environment as well—instead of a browser global since it's being `required`.
