### PR TITLE
Update of the note duration formula to handle more than 3 dots. 

### DIFF
--- a/timbre.dev.js
+++ b/timbre.dev.js
@@ -8835,7 +8835,7 @@
                         dot = cmd.dot || status.dot;
                     }
                     duration = (60 / tempo) * (4 / len) * 1000;
-                    duration *= [1, 1.5, 1.75, 1.875][dot] || 1;
+                    duration *= 2 - (1 / Math.pow(2, dot));
 
                     vel = status.v << 3;
                     if (status.tie) {


### PR DESCRIPTION
Even if it is uncommon, it's theorically correct, and it seems that some generator use to do that.

With that formula is is theorically possible to handle an infinite number of dots as opposed to the previous version which was handling a fixed maximum amount of 3 dots.
