### PR TITLE
make browserify-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timbre",
-  "version": "14.11.25",
+  "version": "14.11.26",
   "description": "JavaScript library for objective sound programming",
   "author": "nao yonamine <mohayonao@gmail.com>",
   "repository": {
@@ -8,6 +8,7 @@
     "url": "https://github.com/mohayonao/timbre.js.git"
   },
   "main": "timbre.node.js",
+  "browser" : "timbre.dev.js",
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
hiii, i've set the browserify entry point to `timbre.dev.js`. this makes your module browserify-compatible (i've tested this locally)

this PR might also resolve https://github.com/mohayonao/timbre.js/issues/18

thx for your work on this module :)
