### PR TITLE
mediastream.js: fixed typo in renaming context.createJavaScriptNode

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2351,6 +2351,14 @@
                 var sys_streamsize = sys.streamsize;
                 var x, dx;
 
+                // https://goo.gl/7K7WLu
+                // Chrome starts AudioContext in 'suspended' state if there was no user interaction
+                // with the page before AudioContext was created. Attempt to resume(), assuming 'play'
+                // is called as a response to user action.
+                if (context.state === 'suspended') {
+                  context.resume();
+                }
+
                 if (sys.samplerate === context.sampleRate) {
                     onaudioprocess = function(e) {
                         var outs = e.outputBuffer;

--- a/src/objects/mediastream.js
+++ b/src/objects/mediastream.js
@@ -93,7 +93,7 @@
             var context = fn._audioContext;
             _.gain = context.createGain();
             _.gain.gain.value = 0;
-            _.node = context.createScriptProcessorNode(1024, 2, 2);
+            _.node = context.createScriptProcessor(1024, 2, 2);
             _.node.onaudioprocess = onaudioprocess(this);
             _.src.connect(_.node);
             _.node.connect(_.gain);


### PR DESCRIPTION
Fixed typo: createScriptProcessorNode -> createScriptProcessor
